### PR TITLE
Improve configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For example, we can add hooks in an initializer:
 
 ```ruby
 # Make IP address accessible to the handlers
-Rails.application.config.service_hooks[:before] = lambda do |rack_env, env|
+Rails.application.config.twirp.service_hooks[:before] = lambda do |rack_env, env|
   env[:ip] = rack_env["REMOTE_ADDR"]
 end
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ end
 Rails.application.config.twirp.service_hooks[:exception_raised] = ->(exception, _env) { Honeybadger.notify(exception) }
 ```
 
+### Middleware
+
+As an Engine, we avoid all the standard Rails middleware. That's nice for simplicity, but sometimes you want to add your own middleware. You can do that by specifying it in an initializer:
+
+```ruby
+Rails.application.config.twirp.middleware = [Rack::Deflater]
+```
+
 ## Bonus Features
 
 Outside the Twirp spec, this is some extra magic. They might be useful to you, but you can easily ignore them too.   
@@ -104,6 +112,14 @@ Like Rails GET actions, Twirp::Rails handlers add [`ETag` headers](https://devel
 
 If you have RPCs can be cached, you can have your Twirp clients send an [`If-None-Match` Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match). Twirp::Rails will return a `304 Not Modified` HTTP status and not re-send the body if the ETag matches. 
 
+Enable by adding this to an initializer: 
+
+```ruby
+Rails.application.config.twirp.middleware = [
+  Twirp::Rails::Rack::ConditionalPost,
+  Rack::ETag
+]
+```
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ mount Twirp::Rails::Engine, at: "/twirp"
 Twirp::Rails will automatically load any `*_twirp.rb` files in your app's `lib/` directory. To modify the location, add this to an initializer: 
 
 ```ruby 
-Twirp::Rails.configure do |config|
-  config.load_paths = ["lib", "app/twirp"]
+Rails.application.config.load_paths = ["lib", "app/twirp"]
 end
 ```
 
@@ -86,15 +85,13 @@ Apply [Service Hooks](https://github.com/twitchtv/twirp-ruby/wiki/Service-Hooks)
 For example, we can add hooks in an initializer: 
 
 ```ruby
-Twirp::Rails.configure do |config|
-  # Make IP address accessible to the handlers
-  config.service_hooks[:before] = lambda do |rack_env, env|
-    env[:ip] = rack_env["REMOTE_ADDR"]
-  end
-
-  # Send exceptions to Honeybadger
-  config.service_hooks[:exception_raised] = ->(exception, _env) { Honeybadger.notify(exception) }
+# Make IP address accessible to the handlers
+Rails.application.config.service_hooks[:before] = lambda do |rack_env, env|
+  env[:ip] = rack_env["REMOTE_ADDR"]
 end
+
+# Send exceptions to Honeybadger
+Rails.application.config.twirp.service_hooks[:exception_raised] = ->(exception, _env) { Honeybadger.notify(exception) }
 ```
 
 ## Bonus Features

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
+Rails.application.routes.draw do
+  if Rails.application.config.twirp.auto_mount
+    mount Twirp::Rails::Engine => Rails.application.config.twirp.endpoint
+  end
+end
+
 Twirp::Rails::Engine.routes.draw do
   Twirp::Rails.services.each do |service|
     mount service, at: service.full_name

--- a/lib/twirp/rails.rb
+++ b/lib/twirp/rails.rb
@@ -16,9 +16,6 @@ require_relative "rails/dispatcher"
 require_relative "rails/engine"
 require_relative "rails/handler"
 
-# Require any _twirp.rb files in lib
-# Dir.glob(Rails.root.join("lib", "*_twirp.rb")).each { |file| require file }
-
 module Twirp
   class Service
     # Override initialize to make handler argument optional.

--- a/lib/twirp/rails/configuration.rb
+++ b/lib/twirp/rails/configuration.rb
@@ -3,18 +3,26 @@
 module Twirp
   module Rails
     class Configuration
-      # A lambda that accepts |rack_env, env| and is passed to Twirp::Service
-      # See: https://github.com/twitchtv/twirp-ruby/wiki/Service-Hooks
-      # for available hooks
-      attr_accessor :service_hooks
+      # Whether to automatically mount routes at /twirp
+      attr_accessor :auto_mount
 
       # An array of directories to search for *_twirp.rb files
       # Defaults to ["lib"]
       attr_accessor :load_paths
 
+      # An array of Rack middleware to use
+      attr_accessor :middleware
+
+      # A hash of lambdas that accepts |rack_env, env| and is passed to Twirp::Service
+      # See: https://github.com/twitchtv/twirp-ruby/wiki/Service-Hooks
+      # for available hooks
+      attr_accessor :service_hooks
+
       def initialize
-        @service_hooks = {}
+        @auto_mount = false
         @load_paths = ["lib"]
+        @middleware = []
+        @service_hooks = {}
       end
     end
   end

--- a/lib/twirp/rails/configuration.rb
+++ b/lib/twirp/rails/configuration.rb
@@ -3,8 +3,11 @@
 module Twirp
   module Rails
     class Configuration
-      # Whether to automatically mount routes at /twirp
+      # Whether to automatically mount routes at endpoint. Defaults to false
       attr_accessor :auto_mount
+
+      # Where to mount twirp routes. Defaults to /twirp
+      attr_accessor :endpoint
 
       # An array of directories to search for *_twirp.rb files
       # Defaults to ["lib"]
@@ -20,6 +23,7 @@ module Twirp
 
       def initialize
         @auto_mount = false
+        @endpoint = "/twirp"
         @load_paths = ["lib"]
         @middleware = []
         @service_hooks = {}

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -7,6 +7,7 @@ require_relative "rack/conditional_post"
 module Twirp
   module Rails
     class Engine < ::Rails::Engine
+      isolate_namespace Twirp::Rails
       engine_name "twirp"
       # endpoint MyRackApplication
       # # Add a load path for this specific Engine

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -12,8 +12,6 @@ module Twirp
       # endpoint MyRackApplication
       # # Add a load path for this specific Engine
       # config.autoload_paths << File.expand_path("lib/some/path", __dir__)
-      # middleware.use Twirp::Rails::Rack::ConditionalPost
-      # middleware.use ::Rack::ETag
 
       config.twirp = Configuration.new
 
@@ -26,6 +24,11 @@ module Twirp
       initializer "twirp.configure" do |app|
         [:auto_mount, :endpoint, :load_paths, :middleware, :service_hooks].each do |key|
           app.config.twirp.send(key)
+        end
+
+        app.config.twirp.middleware.each do |middleware|
+          puts "using #{middleware}"
+          app.config.middleware.use middleware
         end
       end
     end

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -11,23 +11,28 @@ module Twirp
       # endpoint MyRackApplication
       # # Add a load path for this specific Engine
       # config.autoload_paths << File.expand_path("lib/some/path", __dir__)
-      middleware.use Twirp::Rails::Rack::ConditionalPost
-      middleware.use ::Rack::ETag
+      # middleware.use Twirp::Rails::Rack::ConditionalPost
+      # middleware.use ::Rack::ETag
+
+      config.twirp = Configuration.new
+
+      initializer "twirp.configure.defaults", before: "twirp.configure" do |app|
+        twirp = app.config.twirp
+        # twirp.auto_mount = true if twirp.auto_mount.nil?
+        twirp.load_paths ||= ["lib"]
+      end
+
+      initializer "twirp.configure" do |app|
+        [:middleware, :service_hooks, :load_paths].each do |key|
+          app.config.twirp.send(key)
+        end
+      end
     end
 
     class << self
-      def configure
-        yield configuration if block_given?
-        configuration
-      end
-
-      def configuration
-        @configuration ||= Configuration.new
-      end
-
       def services
         if @services.nil?
-          configuration.load_paths.each do |directory|
+          ::Rails.application.config.twirp.load_paths.each do |directory|
             Dir.glob(::Rails.root.join(directory, "*_twirp.rb")).sort.each { |file| require file }
           end
 
@@ -35,7 +40,7 @@ module Twirp
 
           # Install hooks that may be defined in the config
           @services.each do |service|
-            configuration.service_hooks.each do |hook_name, hook|
+            ::Rails.application.config.twirp.service_hooks.each do |hook_name, hook|
               service.send(hook_name, &hook)
             end
           end

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -24,7 +24,7 @@ module Twirp
       end
 
       initializer "twirp.configure" do |app|
-        [:middleware, :service_hooks, :load_paths].each do |key|
+        [:auto_mount, :endpoint, :load_paths, :middleware, :service_hooks].each do |key|
           app.config.twirp.send(key)
         end
       end

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -1,4 +1,9 @@
+require "rails"
+require "action_controller/railtie"
 require "active_record/railtie"
+
+Bundler.require
+require "twirp/rails"
 
 module RailsApp
   class Application < Rails::Application

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@
 ENV["RAILS_ENV"] = "test"
 require "bundler/setup"
 
-require "twirp/rails"
 require "rails_app/config/environment"
 require "rspec/rails"
 


### PR DESCRIPTION
This PR kinda went all over the place, but i like where it ends up:

* Simpler config code
* Configurable middleware (main goal)
* Turned off our Conditional Post stuff by default, with a Readme example of how to enable it. I don't want us forcing anything non-standard by default. 
* Figured out testing bugs preventing us from calling [`isolate_namespace`](https://guides.rubyonrails.org/engines.html#critical-files)
* Add the ability to auto mount the routes.  Disabled by default. I liked the idea, but after implementing it, I'm not sure it is really worth it. Keeps you from having to add `mount Twirp::Rails::Engine, at: "/twirp"` in your `routes.rb`. Is that good? Sometimes being explicit is nice. 🤷 