### PR TITLE
Add an inspect to Twirp::Service to get prettier `rails routes` output

### DIFF
--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -54,3 +54,11 @@ module Twirp
     end
   end
 end
+
+class Twirp::Service
+  # Override inspect to show all available RPCs
+  # This is used when displaying routes.
+  def inspect
+    self.class.rpcs.map { |rpc| "#{self.class.name.demodulize.underscore}_handler##{rpc[1][:ruby_method]}" }.join("\n")
+  end
+end


### PR DESCRIPTION
Completes #5 

This lists all the handlers and methods like normal routes:

`/twirp/example/HaberdasherService  haberdasher_service_handler#make_hat`