### PR TITLE
Fix thread safety error with handlers

### DIFF
--- a/lib/twirp/rails/dispatcher.rb
+++ b/lib/twirp/rails/dispatcher.rb
@@ -4,7 +4,7 @@ module Twirp
   module Rails
     class Dispatcher
       def initialize(service_class)
-        @service_handler = "#{service_class.service_name}Handler".constantize.new
+        @service_handler = "#{service_class.service_name}Handler".constantize
       end
 
       def respond_to_missing?(method, *)
@@ -14,7 +14,7 @@ module Twirp
       def method_missing(name, *args)
         request = args[0]
         env = args[1]
-        @service_handler.process(name, request, env)
+        @service_handler.new.process(name, request, env)
       end
     end
   end


### PR DESCRIPTION
`process` sets instance variables that get used in the hander so handler instances can not be shared across requests.