### PR TITLE
Use the gem name twirp-on-rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - '3.0' # keep as string or it turns into "3" which pulls the newest 3.x, not 3.0.x
           - 3.1
           - 3.2
+          - 3.3
 
     env:
       RUBYOPT: --enable=frozen-string-literal

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rake"
 
 gem "debug"
 gem "rspec-rails"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 gem "standard"
 gem "standard-performance"
 gem "standard-rails"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/collectiveidea/twirp-rails/actions/workflows/ci.yml/badge.svg)](https://github.com/collectiveidea/twirp-rails/actions/workflows/ci.yml)
 [![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
 
-# Twirp::Rails
+# Twirp on Rails (Twirp::Rails)
 
 ## Motivation
 
@@ -15,11 +15,11 @@ Extracted from a real, production application with many thousands of users.
 
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add twirp-rails
+    $ bundle add twirp-on-rails
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    $ gem install twirp-rails
+    $ gem install twirp-on-rails
 
 ## Usage
 
@@ -141,7 +141,6 @@ We evaluated all these projects and found them to be bad fits for us, for one re
 * Nice routing abstraction
 * Minimal Handler abstraction
 * Untouched for 4 years
-* Special thanks to [@nikushi](https://github.com/nikushi) for allowing us to take over the [`twirp-rails` gem](http://rubygems.org/gems/twirp-rails) name ( v0.1.1 was that repo). Thanks for your inspiration!
 
 [cheddar-me/rails-twirp](https://github.com/cheddar-me/rails-twirp)
 

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -36,7 +36,7 @@ module Twirp
       def services
         if @services.nil?
           ::Rails.application.config.twirp.load_paths.each do |directory|
-            Dir.glob(::Rails.root.join(directory, "**", "*_twirp.rb")).sort.each { |file| require file }
+            ::Rails.root.glob("#{directory}/**/*_twirp.rb").sort.each { |file| require file }
           end
 
           @services = Twirp::Service.subclasses.map(&:new)

--- a/twirp-rails.gemspec
+++ b/twirp-rails.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/twirp/rails/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "twirp-rails"
+  spec.name = "twirp-on-rails"
   spec.version = Twirp::Rails::VERSION
   spec.authors = ["Daniel Morrison", "Darron Schall"]
   spec.email = ["info@collectiveidea.com"]


### PR DESCRIPTION
I was expecting to get access to the `twirp-rails` gem name, but it hasn't happened (yet?) so let's get it out under this name.

I'm choosing to keep the `Twirp::Rails` structure rather than `Twirp::On::Rails` because… 🤷. I like it better this way.
