### PR TITLE
Add a stub file to allow typical installs to require the gem properly

### DIFF
--- a/lib/twirp/on/rails.rb
+++ b/lib/twirp/on/rails.rb
@@ -1,0 +1,3 @@
+# The gem _should_ put everyting in twirp/on/rails but I don't like "on"
+# being a directory, so this file just requires twirp/rails.rb.
+require_relative "../rails"

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -3,7 +3,8 @@ require "action_controller/railtie"
 require "active_record/railtie"
 
 Bundler.require
-require "twirp/rails"
+require "twirp/on/rails" # test it how a typical install would require it
+# require "twirp/rails"
 
 module RailsApp
   class Application < Rails::Application


### PR DESCRIPTION
Need this after #10 as a typical Gemfile install wants to require `twirp/on/rails.rb` instead of our `twirp/rails.rb`