### PR TITLE
Allow handlers to use rescue_from in a way familiar to ActionController users

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ TODO: Give more examples of handlers
 
 Use `before_action`, `around_action`, and other callbacks you're used to, as we build on [AbstractController::Callbacks](https://api.rubyonrails.org/classes/AbstractController/Callbacks.html).
 
+### rescue_from
+
+Use `rescue_from` just like you would in a controller: 
+
+```ruby
+class HaberdasherServiceHandler < Twirp::Rails::Handler
+  rescue_from "ArgumentError" do |error|
+    Twirp::Error.invalid_argument(error.message)
+  end
+
+  rescue_from "Pundit::NotAuthorizedError", :not_authorized
+
+  ...
+end
+```
+
 ### DRY Service Hooks
 
 Apply [Service Hooks](https://github.com/twitchtv/twirp-ruby/wiki/Service-Hooks) one time across multiple services.

--- a/lib/twirp/rails.rb
+++ b/lib/twirp/rails.rb
@@ -15,6 +15,7 @@ require_relative "rails/callbacks"
 require_relative "rails/configuration"
 require_relative "rails/dispatcher"
 require_relative "rails/engine"
+require_relative "rails/rescuable"
 require_relative "rails/handler"
 
 module Twirp

--- a/lib/twirp/rails/rescuable.rb
+++ b/lib/twirp/rails/rescuable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Twirp
+  module Rails
+    module Rescuable
+      refine ::ActiveSupport::Rescuable::ClassMethods do
+        # A slightly altered version of ActiveSupport::Rescuable#rescue_with_handler
+        # that returns the result rather than the handled exception
+        def rescue_with_handler_and_return(exception, object: self, visited_exceptions: [])
+          visited_exceptions << exception
+
+          if (handler = handler_for_rescue(exception, object: object))
+            handler.call exception
+          elsif exception
+            if visited_exceptions.include?(exception.cause)
+              nil
+            else
+              rescue_with_handler(exception.cause, object: object, visited_exceptions: visited_exceptions)
+            end
+          end
+        end
+      end
+
+      refine ::ActiveSupport::Rescuable do
+        def rescue_with_handler_and_return(exception)
+          self.class.rescue_with_handler_and_return exception, object: self
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_app/app/handlers/haberdasher_handler.rb
+++ b/spec/rails_app/app/handlers/haberdasher_handler.rb
@@ -3,6 +3,10 @@ class HaberdasherHandler < Twirp::Rails::Handler
   before_action :track_request_ip
   before_action :reject_giant_hats
 
+  rescue_from "ArgumentError" do |error|
+    Twirp::Error.invalid_argument(error.message)
+  end
+
   def make_hat
     # We can return a Twirp::Error when appropriate
     if request.inches < 12

--- a/spec/requests/haberdasher_spec.rb
+++ b/spec/requests/haberdasher_spec.rb
@@ -145,4 +145,23 @@ RSpec.describe "Haberdasher Service", type: :request do
       expect(response.status).to eq(304)
     end
   end
+
+  describe "Rescuable" do
+    it "rescues from ArgumentError" do
+      size = Twirp::Example::Haberdasher::Size.new(inches: 100)
+
+      # Fake an exception
+      expect(Twirp::Example::Haberdasher::Hat).to receive(:new).and_raise(ArgumentError.new("is way too large"))
+
+      post "/twirp/twirp.example.haberdasher.Haberdasher/MakeHat",
+        params: size.to_proto, headers: {
+          :accept => "application/protobuf",
+          "Content-Type" => "application/protobuf"
+        }
+
+      expect(response.status).to eq(400)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to eq('{"code":"invalid_argument","msg":"is way too large"}')
+    end
+  end
 end


### PR DESCRIPTION
ActiveSupport::Rescuable does close to what we need, but rather than calling render or redirect, handlers return an object (which may be a Twirp::Error). We refine ActiveSupport::Rescuable to return the result of the rescue_from block/method.

- [x] Add docs to README