### PR TITLE
Update CI build matrix to be more automatic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,27 +8,48 @@ on:
   pull_request:
 
 jobs:
-  build:
+  versions:
+    name: Get latest versions
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby:
-          - 2.7
-          - '3.0' # keep as string or it turns into "3" which pulls the newest 3.x, not 3.0.x
-          - 3.1
-          - 3.2
-          - 3.3
+        product: ["ruby", "rails"]
+    outputs:
+      ruby: ${{ steps.supported.outputs.ruby }}
+      rails: ${{ steps.supported.outputs.rails }}
+    steps:
+      - id: supported
+        run: |
+          product="${{ matrix.product }}"
+          data=$(curl https://endoflife.date/api/$product.json)
+          supported=$(echo $data | jq '[.[] | select(.eol > (now | strftime("%Y-%m-%d")))]')
+          echo "${product}=$(echo $supported | jq -c 'map(.latest)')" >> $GITHUB_OUTPUT
+  build:
+    needs: versions
+    runs-on: ubuntu-latest
+    name: Test on Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ${{ fromJSON(needs.versions.outputs.ruby) }}
+        rails: ${{ fromJSON(needs.versions.outputs.rails) }}
 
     env:
+      RAILS_VERSION: ${{ matrix.rails }}
       RUBYOPT: --enable=frozen-string-literal
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
+      id: setup-ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+      continue-on-error: true
+    - name: Incompatible Versions
+      if: steps.setup-ruby.outcome == 'failure'
+      run: echo "Ruby ${{ matrix.ruby }} is not supported with Rails ${{ matrix.rails }}"
     - name: Run the default task
+      if: steps.setup-ruby.outcome != 'failure'
       run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemspec
 
 gem "rake"
 
+gem "rails", "~> #{ENV["RAILS_VERSION"] || "8.0"}"
+
 gem "debug"
 gem "rspec-rails"
 gem "standard", ">= 1.35.1"


### PR DESCRIPTION
Rails 8 changed sqlite3 version requirements and made the matrix harder to do by hand.

This idea is 100% stolen from @bkeepers at https://github.com/bkeepers/dotenv/pull/521